### PR TITLE
[PC-1301] Update deprecated API

### DIFF
--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -20,7 +20,7 @@ users:
 - name: ${kubeconfig_name}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: ${aws_authenticator_command}
       args:
 %{~ for i in aws_authenticator_command_args }


### PR DESCRIPTION
Applying add-ons for Kubernetes 1.25 fails with following error. We need to update deprecated API.

`error: exec plugin: invalid apiVersion "[client.authentication.k8s.io/v1alpha1](http://client.authentication.k8s.io/v1alpha1)"`

More info: https://eburydev.slack.com/archives/C04608VVANS/p1698923384144599